### PR TITLE
[FEAT] 워크스페이스 현재 접속인원 WS 이벤트 추가

### DIFF
--- a/package.json
+++ b/package.json
@@ -77,6 +77,7 @@
     "jest": "^30.0.0",
     "prettier": "^3.4.2",
     "prisma": "^7",
+    "socket.io-client": "4.8.3",
     "source-map-support": "^0.5.21",
     "supertest": "^7.0.0",
     "ts-jest": "^29.2.5",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -174,6 +174,9 @@ importers:
       prisma:
         specifier: ^7
         version: 7.8.0(@types/react@19.2.14)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(typescript@5.9.3)
+      socket.io-client:
+        specifier: 4.8.3
+        version: 4.8.3
       source-map-support:
         specifier: ^0.5.21
         version: 0.5.21
@@ -2445,6 +2448,9 @@ packages:
     resolution: {integrity: sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg==}
     engines: {node: '>= 0.8'}
 
+  engine.io-client@6.6.4:
+    resolution: {integrity: sha512-+kjUJnZGwzewFDw951CDWcwj35vMNf2fcj7xQWOctq1F2i1jkDdVvdFG9kM/BEChymCH36KgjnW0NsL58JYRxw==}
+
   engine.io-parser@5.2.3:
     resolution: {integrity: sha512-HqD3yTBfnBxIrbnM1DoD6Pcq8NECnh8d4As1Qgh0z5Gg3jRRIqijury0CL3ghu/edArpUYiYqQiDUQBIs4np3Q==}
     engines: {node: '>=10.0.0'}
@@ -3850,6 +3856,10 @@ packages:
   socket.io-adapter@2.5.6:
     resolution: {integrity: sha512-DkkO/dz7MGln0dHn5bmN3pPy+JmywNICWrJqVWiVOyvXjWQFIv9c2h24JrQLLFJ2aQVQf/Cvl1vblnd4r2apLQ==}
 
+  socket.io-client@4.8.3:
+    resolution: {integrity: sha512-uP0bpjWrjQmUt5DTHq9RuoCBdFJF10cdX9X+a368j/Ft0wmaVgxlrjvK3kjvgCODOMMOz9lcaRzxmso0bTWZ/g==}
+    engines: {node: '>=10.0.0'}
+
   socket.io-parser@4.2.5:
     resolution: {integrity: sha512-bPMmpy/5WWKHea5Y/jYAP6k74A+hvmRCQaJuJB6I/ML5JZq/KfNieUVo/3Mh7SAqn7TyFdIo6wqYHInG1MU1bQ==}
     engines: {node: '>=10.0.0'}
@@ -4292,6 +4302,10 @@ packages:
         optional: true
       utf-8-validate:
         optional: true
+
+  xmlhttprequest-ssl@2.1.2:
+    resolution: {integrity: sha512-TEU+nJVUUnA4CYJFLvK5X9AOeH4KvDvhIfm0vV1GaQRtchnG0hgK5p8hw/xjv8cunWYCsiPCSDzObPyhEwq3KQ==}
+    engines: {node: '>=0.4.0'}
 
   xtend@4.0.2:
     resolution: {integrity: sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ==}
@@ -7162,6 +7176,18 @@ snapshots:
 
   encodeurl@2.0.0: {}
 
+  engine.io-client@6.6.4:
+    dependencies:
+      '@socket.io/component-emitter': 3.1.2
+      debug: 4.4.3
+      engine.io-parser: 5.2.3
+      ws: 8.18.3
+      xmlhttprequest-ssl: 2.1.2
+    transitivePeerDependencies:
+      - bufferutil
+      - supports-color
+      - utf-8-validate
+
   engine.io-parser@5.2.3: {}
 
   engine.io@6.6.5:
@@ -8764,6 +8790,17 @@ snapshots:
       - supports-color
       - utf-8-validate
 
+  socket.io-client@4.8.3:
+    dependencies:
+      '@socket.io/component-emitter': 3.1.2
+      debug: 4.4.3
+      engine.io-client: 6.6.4
+      socket.io-parser: 4.2.5
+    transitivePeerDependencies:
+      - bufferutil
+      - supports-color
+      - utf-8-validate
+
   socket.io-parser@4.2.5:
     dependencies:
       '@socket.io/component-emitter': 3.1.2
@@ -9235,6 +9272,8 @@ snapshots:
       signal-exit: 4.1.0
 
   ws@8.18.3: {}
+
+  xmlhttprequest-ssl@2.1.2: {}
 
   xtend@4.0.2: {}
 

--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -3,6 +3,7 @@ import { ConfigModule } from '@nestjs/config';
 import { ServeStaticModule } from '@nestjs/serve-static';
 import { join } from 'path';
 import { AppController } from './app.controller';
+import { RequestContextMiddleware } from './common/context/request-context.middleware';
 import { AppService } from './app.service';
 import { PrismaModule } from './prisma/prisma.module';
 import { UserModule } from './user/user.module';
@@ -37,4 +38,8 @@ import { createWinstonConsoleTransport } from './common/logging/winston.console'
   controllers: [AppController],
   providers: [AppService]
 })
-export class AppModule {}
+export class AppModule implements NestModule {
+  configure(consumer: MiddlewareConsumer) {
+    consumer.apply(RequestContextMiddleware).forRoutes('*');
+  }
+}

--- a/src/common/context/request-context.middleware.ts
+++ b/src/common/context/request-context.middleware.ts
@@ -1,0 +1,21 @@
+import { Injectable, NestMiddleware } from '@nestjs/common';
+import { Request, Response, NextFunction } from 'express';
+import { v4 as uuidv4 } from 'uuid';
+import { requestContextStorage } from './request.context';
+
+@Injectable()
+export class RequestContextMiddleware implements NestMiddleware {
+  use(req: Request, res: Response, next: NextFunction) {
+    const incoming = req.headers['x-request-id'];
+    const requestId =
+      (typeof incoming === 'string' && incoming.length > 0
+        ? incoming
+        : Array.isArray(incoming)
+          ? incoming[0]
+          : null) ?? uuidv4();
+
+    res.setHeader('X-Request-Id', requestId);
+
+    requestContextStorage.run({ requestId, userId: null }, () => next());
+  }
+}

--- a/src/common/context/request.context.ts
+++ b/src/common/context/request.context.ts
@@ -1,0 +1,11 @@
+import { AsyncLocalStorage } from 'async_hooks';
+
+export interface RequestContext {
+  requestId: string;
+  userId?: string | null;
+}
+
+export const requestContextStorage = new AsyncLocalStorage<RequestContext>();
+
+export const getRequestContext = (): RequestContext | undefined =>
+  requestContextStorage.getStore();

--- a/src/common/logging/log-format.ts
+++ b/src/common/logging/log-format.ts
@@ -1,0 +1,61 @@
+import { isProduction } from './logging.config';
+
+export type HttpLogKind = 'request' | 'response';
+
+export interface HttpLogPayload {
+  requestId: string;
+  userId: string | null;
+  ip?: string;
+  method: string;
+  url: string;
+  statusCode?: number;
+  ms?: number;
+}
+
+export function formatHttpLog(
+  kind: HttpLogKind,
+  payload: HttpLogPayload
+): string {
+  if (isProduction()) {
+    return JSON.stringify({ type: kind, ...payload });
+  }
+  if (kind === 'request') {
+    return `[Request] userId : ${payload.userId} ${payload.method} ${payload.url}`;
+  }
+  return `[Response] ${payload.method} ${payload.url} ${payload.statusCode} - ${payload.ms}ms`;
+}
+
+export type PrismaLogKind = 'query' | 'slow' | 'error';
+
+export interface PrismaLogPayload {
+  label: string;
+  ms: number;
+  requestId?: string;
+  userId?: string | null;
+  inTransaction: boolean;
+  code?: string;
+  message?: string;
+}
+
+export function formatPrismaLog(
+  kind: PrismaLogKind,
+  payload: PrismaLogPayload
+): string {
+  if (isProduction()) {
+    return JSON.stringify({ type: `prisma.${kind}`, ...payload });
+  }
+  const meta = {
+    requestId: payload.requestId,
+    userId: payload.userId,
+    inTransaction: payload.inTransaction
+  };
+  const metaStr = JSON.stringify(meta);
+  const ms = payload.ms.toFixed(2);
+  if (kind === 'query') {
+    return `[${payload.label}] ${ms}ms ${metaStr}`;
+  }
+  if (kind === 'slow') {
+    return `Slow query: ${payload.label} - ${ms}ms ${metaStr}`;
+  }
+  return `Query failed: ${payload.label} - ${ms}ms code=${payload.code} ${metaStr} :: ${payload.message}`;
+}

--- a/src/common/logging/logging.config.ts
+++ b/src/common/logging/logging.config.ts
@@ -1,0 +1,24 @@
+const parsePositiveInt = (
+  value: string | undefined,
+  fallback: number
+): number => {
+  if (!value) return fallback;
+  const n = Number(value);
+  return Number.isFinite(n) && n > 0 ? n : fallback;
+};
+
+const parseCsv = (value: string | undefined, fallback: string[]): string[] => {
+  if (!value) return fallback;
+  const parts = value
+    .split(',')
+    .map((s) => s.trim())
+    .filter(Boolean);
+  return parts.length > 0 ? parts : fallback;
+};
+
+export const SLOW_QUERY_MS = parsePositiveInt(process.env.SLOW_QUERY_MS, 500);
+
+export const LOG_SKIP_URLS = parseCsv(process.env.LOG_SKIP_URLS, ['/metrics']);
+
+export const isProduction = (): boolean =>
+  process.env.NODE_ENV === 'production';

--- a/src/common/logging/logging.interceptor.ts
+++ b/src/common/logging/logging.interceptor.ts
@@ -11,7 +11,9 @@ import { WINSTON_MODULE_NEST_PROVIDER } from 'nest-winston';
 import { Observable, throwError } from 'rxjs';
 import { catchError, tap } from 'rxjs/operators';
 import { Request, Response } from 'express';
-import { v4 as uuidv4 } from 'uuid';
+import { getRequestContext } from '../context/request.context';
+import { LOG_SKIP_URLS } from './logging.config';
+import { formatHttpLog } from './log-format';
 
 @Injectable()
 export class LoggingInterceptor implements NestInterceptor {
@@ -19,91 +21,64 @@ export class LoggingInterceptor implements NestInterceptor {
     @Inject(WINSTON_MODULE_NEST_PROVIDER) private readonly logger: LoggerService
   ) {}
 
-  private static readonly SKIP_URLS = ['/metrics'];
-
   intercept(context: ExecutionContext, next: CallHandler): Observable<any> {
     const req = context.switchToHttp().getRequest<Request>();
     const res = context.switchToHttp().getResponse<Response>();
     const { method, url } = req;
-    const isProd = process.env.NODE_ENV === 'production';
 
-    if (LoggingInterceptor.SKIP_URLS.some((skip) => url.startsWith(skip))) {
+    if (LOG_SKIP_URLS.some((skip) => url.startsWith(skip))) {
       return next.handle();
     }
+
     const ip =
       (req.headers['x-forwarded-for'] as string)?.split(',')[0]?.trim() ??
       req.ip;
     const userId = (req as any).user?.user_id ?? null;
-    const requestId = uuidv4();
+    const ctx = getRequestContext();
+    const requestId = ctx?.requestId ?? 'no-context';
+    if (ctx) {
+      ctx.userId = userId;
+    }
     const start = Date.now();
 
-    // Attach requestId to response header for tracing
-    res.setHeader('X-Request-Id', requestId);
-
-    isProd
-      ? this.logger.log(
-          JSON.stringify({
-            type: 'request',
-            requestId,
-            userId,
-            ip,
-            method,
-            url
-          }),
-          'HTTP'
-        )
-      : this.logger.log(
-          `[Request] userId : ${userId} ${method} ${url}`,
-          'HTTP'
-        );
+    this.logger.log(
+      formatHttpLog('request', { requestId, userId, ip, method, url }),
+      'HTTP'
+    );
 
     return next.handle().pipe(
       tap(() => {
         const ms = Date.now() - start;
-        const statusCode = res.statusCode;
-        isProd
-          ? this.logger.log(
-              JSON.stringify({
-                type: 'response',
-                requestId,
-                userId,
-                ip,
-                method,
-                url,
-                statusCode,
-                ms
-              }),
-              'HTTP'
-            )
-          : this.logger.log(
-              `[Response] ${method} ${url} ${statusCode} - ${ms}ms`,
-              'HTTP'
-            );
+        this.logger.log(
+          formatHttpLog('response', {
+            requestId,
+            userId,
+            ip,
+            method,
+            url,
+            statusCode: res.statusCode,
+            ms
+          }),
+          'HTTP'
+        );
       }),
       catchError((err) => {
         const ms = Date.now() - start;
         const statusCode = err instanceof HttpException ? err.getStatus() : 500;
         const stack = err instanceof Error ? err.stack : undefined;
-        isProd
-          ? this.logger.error(
-              JSON.stringify({
-                type: 'response',
-                requestId,
-                userId,
-                ip,
-                method,
-                url,
-                statusCode,
-                ms
-              }),
-              stack,
-              'HTTP'
-            )
-          : this.logger.error(
-              `[Response] ${method} ${url} ${statusCode} - ${ms}ms`,
-              stack,
-              'HTTP'
-            );
+        this.logger.error(
+          formatHttpLog('response', {
+            requestId,
+            userId,
+            ip,
+            method,
+            url,
+            statusCode,
+            ms
+          }),
+          stack,
+          'HTTP'
+        );
         return throwError(() => err);
       })
     );

--- a/src/common/response/api-error-response.decorator.ts
+++ b/src/common/response/api-error-response.decorator.ts
@@ -1,0 +1,43 @@
+import { applyDecorators } from '@nestjs/common';
+import { ApiResponse } from '@nestjs/swagger';
+import { SchemaObject } from '@nestjs/swagger/dist/interfaces/open-api-spec.interface';
+
+export interface ApiErrorResponseOptions {
+  errorCode?: string;
+  description?: string;
+  data?: unknown;
+}
+
+export const ApiErrorResponse = (
+  status: number,
+  reason: string,
+  options: ApiErrorResponseOptions = {}
+) => {
+  const errorCode = options.errorCode ?? `HTTP-${status}`;
+  const data = options.data ?? '';
+
+  const responseSchema: SchemaObject = {
+    properties: {
+      resultType: { type: 'string', example: 'FAIL' },
+      error: {
+        type: 'object',
+        properties: {
+          errorCode: { type: 'string', example: errorCode },
+          reason: { type: 'string', example: reason },
+          data: { example: data }
+        },
+        required: ['errorCode', 'reason', 'data']
+      },
+      success: { nullable: true, example: null }
+    },
+    required: ['resultType', 'error', 'success']
+  };
+
+  return applyDecorators(
+    ApiResponse({
+      status,
+      description: options.description ?? reason,
+      schema: responseSchema
+    })
+  );
+};

--- a/src/node/node.module.ts
+++ b/src/node/node.module.ts
@@ -1,4 +1,4 @@
-import { Module } from '@nestjs/common';
+import { forwardRef, Module } from '@nestjs/common';
 import { NodeService } from './node.service';
 import { NodeController } from './node.controller';
 import { NodeRepository } from './node.repository';
@@ -7,7 +7,7 @@ import { EdgeRepository } from 'src/edge/edge.repository';
 import { WsModule } from 'src/ws/ws.module';
 
 @Module({
-  imports: [WsModule],
+  imports: [forwardRef(() => WsModule)],
   controllers: [NodeController],
   providers: [NodeService, NodeRepository, WorkspaceRepository, EdgeRepository],
   exports: [NodeRepository, NodeService]

--- a/src/node/node.service.ts
+++ b/src/node/node.service.ts
@@ -1,4 +1,6 @@
 import {
+  forwardRef,
+  Inject,
   Injectable,
   NotFoundException,
   UnauthorizedException
@@ -24,6 +26,7 @@ export class NodeService {
     private readonly nodeRespository: NodeRepository,
     private readonly workspaceRepository: WorkspaceRepository,
     private readonly edgeRepository: EdgeRepository,
+    @Inject(forwardRef(() => WsGateway))
     private readonly wsGateway: WsGateway,
     private readonly redisService: RedisService
   ) {}

--- a/src/prisma/prisma.service.ts
+++ b/src/prisma/prisma.service.ts
@@ -30,8 +30,8 @@ export class PrismaService implements OnModuleInit, OnModuleDestroy {
 
   private readonly prisma = new PrismaClient({
     adapter: new PrismaPg(
-      { connectionString: process.env.DATABASE_URL! },
-      { schema: 'aideep' } //FIX: 환경변수로 분리
+      { connectionString: process.env.DATABASE_URL },
+      { schema: process.env.DATABASE_SCHEMA } //FIX: 환경변수로 분리
     )
   }).$extends({
     query: {

--- a/src/prisma/prisma.service.ts
+++ b/src/prisma/prisma.service.ts
@@ -1,62 +1,120 @@
-import { Injectable, OnModuleDestroy, OnModuleInit } from '@nestjs/common';
+import {
+  Inject,
+  Injectable,
+  Logger,
+  LoggerService,
+  OnModuleDestroy,
+  OnModuleInit
+} from '@nestjs/common';
+import { WINSTON_MODULE_NEST_PROVIDER } from 'nest-winston';
 import { PrismaPg } from '@prisma/adapter-pg';
 import { Prisma, PrismaClient } from '../generated/prisma/client';
+import { getRequestContext } from '../common/context/request.context';
+import { SLOW_QUERY_MS, isProduction } from '../common/logging/logging.config';
+import { formatPrismaLog } from '../common/logging/log-format';
 import {
   transactionStorage,
   setTransactionRunner
 } from './transaction.storage';
 
+type QueryParams = {
+  operation: string;
+  model?: string;
+  args: unknown;
+  query: (args: unknown) => Promise<unknown>;
+};
+
 @Injectable()
 export class PrismaService implements OnModuleInit, OnModuleDestroy {
+  private readonly nestLogger = new Logger(PrismaService.name);
+
   private readonly prisma = new PrismaClient({
     adapter: new PrismaPg(
       { connectionString: process.env.DATABASE_URL! },
       { schema: 'aideep' } //FIX: 환경변수로 분리
     )
+  }).$extends({
+    query: {
+      $allOperations: (params) => this.logQuery(params as QueryParams)
+    }
   });
 
+  constructor(
+    @Inject(WINSTON_MODULE_NEST_PROVIDER)
+    private readonly winstonLogger: LoggerService
+  ) {}
+
   get client(): Prisma.TransactionClient {
-    return transactionStorage.getStore() ?? this.prisma;
+    return (
+      transactionStorage.getStore() ??
+      (this.prisma as unknown as Prisma.TransactionClient)
+    );
   }
 
   async runInTransaction<T>(fn: () => Promise<T>): Promise<T> {
     if (transactionStorage.getStore()) {
       return fn();
     }
-    return this.prisma.$transaction((tx) => transactionStorage.run(tx, fn));
+    return this.prisma.$transaction((tx) =>
+      transactionStorage.run(tx as unknown as Prisma.TransactionClient, fn)
+    );
   }
 
   async onModuleInit() {
     setTransactionRunner(this.runInTransaction.bind(this));
-    this.prisma.$extends({
-      query: {
-        async $allOperations({
-          operation,
-          model,
-          args,
-          query
-        }: {
-          model?: string;
-          operation: string;
-          args: unknown;
-          query: (a: unknown) => Promise<unknown>;
-        }) {
-          const start = performance.now();
-          const result = await query(args);
-          const ms = performance.now() - start;
-          const label = `${model ?? '?'}.${operation}`;
-          console.log(`[${label}] ${ms.toFixed(2)}ms`);
-          if (ms > 500) {
-            console.warn(`Slow query: ${label} - ${ms.toFixed(2)}ms`);
-          }
-          return result;
-        }
-      }
-    });
     await this.prisma.$connect();
   }
 
   async onModuleDestroy() {
     await this.prisma.$disconnect();
+  }
+
+  private async logQuery({ operation, model, args, query }: QueryParams) {
+    const start = performance.now();
+    const label = `${model ?? '?'}.${operation}`;
+    const inTransaction = !!transactionStorage.getStore();
+    const ctx = getRequestContext();
+    const base = {
+      label,
+      requestId: ctx?.requestId,
+      userId: ctx?.userId,
+      inTransaction
+    };
+
+    try {
+      const result = await query(args);
+      const ms = performance.now() - start;
+      this.log('debug', formatPrismaLog('query', { ...base, ms }));
+      if (ms > SLOW_QUERY_MS) {
+        this.log('warn', formatPrismaLog('slow', { ...base, ms }));
+      }
+      return result;
+    } catch (err) {
+      const ms = performance.now() - start;
+      const code =
+        err instanceof Prisma.PrismaClientKnownRequestError
+          ? err.code
+          : err instanceof Error
+            ? err.name
+            : 'unknown';
+      const message = err instanceof Error ? err.message : String(err);
+      this.log(
+        'error',
+        formatPrismaLog('error', { ...base, ms, code, message })
+      );
+      throw err;
+    }
+  }
+
+  private log(level: 'debug' | 'warn' | 'error', message: string) {
+    const logger = isProduction() ? this.winstonLogger : this.nestLogger;
+    const context = PrismaService.name;
+    if (level === 'debug') {
+      logger.debug?.(message, context);
+    } else if (level === 'warn') {
+      logger.warn(message, context);
+    } else {
+      logger.error(message, undefined, context);
+    }
   }
 }

--- a/src/redis/redis.keys.ts
+++ b/src/redis/redis.keys.ts
@@ -8,5 +8,6 @@ export const REDIS_KEYS = {
   WORKSPACE_SYNC: (workspaceId: string) => `workspace:sync:${workspaceId}`,
   INVITE_WORKSPACE: (workspaceId: string) => `inviteCode:${workspaceId}`,
   YJS_DOC: (nodeId: string) => `yjs:doc:${nodeId}`,
-  YJS_WS_AWARENESS: (workspaceId: string) => `yjs:ws:awareness:${workspaceId}`
+  YJS_WS_AWARENESS: (workspaceId: string) => `yjs:ws:awareness:${workspaceId}`,
+  WS_PRESENCE: (workspaceId: string) => `ws:presence:${workspaceId}`
 };

--- a/src/workspace/dto/leaveWorkspace.dto.ts
+++ b/src/workspace/dto/leaveWorkspace.dto.ts
@@ -1,0 +1,19 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { IsString } from 'class-validator';
+
+export class LeaveWorkspaceBody {
+  @IsString()
+  @ApiProperty({
+    example: '422e16a9-fc48-4c0f-b2fc-1d8b94e2792a',
+    description: '떠날 워크스페이스의 UUID'
+  })
+  workspaceId: string;
+}
+
+export class LeaveWorkspaceResponseDto {
+  @ApiProperty({
+    example: '422e16a9-fc48-4c0f-b2fc-1d8b94e2792a',
+    description: '떠난 워크스페이스의 UUID'
+  })
+  workspaceId: string;
+}

--- a/src/workspace/dto/leaveWorkspace.ts
+++ b/src/workspace/dto/leaveWorkspace.ts
@@ -1,6 +1,0 @@
-import { IsString } from 'class-validator';
-
-export class LeaveWorkspaceBody {
-  @IsString()
-  workspaceId: string;
-}

--- a/src/workspace/dto/renameWorkspace.dto.ts
+++ b/src/workspace/dto/renameWorkspace.dto.ts
@@ -1,0 +1,12 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { IsNotEmpty, IsString } from 'class-validator';
+
+export class RenameWorkspaceBody {
+  @ApiProperty({
+    example: '새로운 이름',
+    description: '새로운 워크스페이스 이름'
+  })
+  @IsString()
+  @IsNotEmpty()
+  title: string;
+}

--- a/src/workspace/workspace.controller.ts
+++ b/src/workspace/workspace.controller.ts
@@ -82,7 +82,7 @@ export class WorkspaceController {
   @ApiErrorResponse(404, '해당 유저의 워크스페이스가 존재하지 않습니다.')
   @ApiErrorResponse(
     400,
-    '다른 멤버가 남아 있어 OWNER는 떠날 수 없습니다. 소유권을 이전 하거나, 삭제해주세요.'
+    'OWNER는 워크스페이스를 떠날 수 없습니다. 소유권을 이전하거나 워크스페이스를 삭제해주세요.'
   )
   async leaveWorkspace(@Request() req: any, @Body() body: LeaveWorkspaceBody) {
     const userId = req.user?.user_id;
@@ -109,6 +109,34 @@ export class WorkspaceController {
     const userId = req.user?.user_id;
     await this.workspaceService.joinWorkspace(body.code, userId, workspaceId);
     return '참가 성공';
+  }
+
+  @Delete('/:workspaceId')
+  @ApiOperation({
+    summary: '워크스페이스 삭제',
+    description:
+      'OWNER 유저가 워크스페이스를 soft-delete 합니다. 워크스페이스와 모든 멤버십 행이 함께 삭제됩니다.'
+  })
+  @ApiSuccessResponse(
+    {
+      type: 'string',
+      example: '삭제 성공'
+    },
+    200
+  )
+  @ApiErrorResponse(404, '해당 유저의 워크스페이스가 존재하지 않습니다.')
+  @ApiErrorResponse(
+    403,
+    'OWNER가 아닌 유저는 워크스페이스를 삭제할 수 없습니다.'
+  )
+  @ApiErrorResponse(400, '워크스페이스가 최소 한개는 남아있어야 합니다.')
+  async deleteWorkspace(
+    @Request() req: any,
+    @Param('workspaceId') workspaceId: string
+  ) {
+    const userId = req.user.user_id;
+    await this.workspaceService.deleteWorkspace(workspaceId, userId);
+    return '삭제 성공';
   }
 
   @Get('sync')

--- a/src/workspace/workspace.controller.ts
+++ b/src/workspace/workspace.controller.ts
@@ -11,6 +11,7 @@ import {
 } from '@nestjs/common';
 import { JwtAuthGuard } from 'src/auth/guards/jwt.guard';
 import { ApiBearerAuth, ApiBody, ApiOperation } from '@nestjs/swagger';
+import { ApiErrorResponse } from 'src/common/response/api-error-response.decorator';
 import {
   CreateWorkspaceBody,
   CreateWorkspaceResponseDto
@@ -22,7 +23,10 @@ import {
 } from './dto/joinWorkspace.dto';
 import { ApiSuccessResponse } from 'src/common/response/api-success-response.decorator';
 import { UserWokrpaceInfoDto, WorkspaceInfoDto } from './dto/workspaceInfo.dto';
-import { LeaveWorkspaceBody } from './dto/leaveWorkspace';
+import {
+  LeaveWorkspaceBody,
+  LeaveWorkspaceResponseDto
+} from './dto/leaveWorkspace.dto';
 
 @Controller('workspace')
 @UseGuards(JwtAuthGuard)
@@ -69,14 +73,16 @@ export class WorkspaceController {
 
   @Delete('/leave')
   @ApiOperation({
-    summary: '특정 워크스페이스를 떠납니다.'
+    summary: '특정 워크스페이스를 떠납니다.',
+    description:
+      '현재 유저를 해당 워크스페이스에서 제거합니다. OWNER인 경우 다른 멤버가 남아 있으면 떠날 수 없으며, 마지막 OWNER가 떠나면 워크스페이스는 soft delete 됩니다.'
   })
-  @ApiSuccessResponse(
-    {
-      type: 'object',
-      properties: { workspaceId: { type: 'string' } }
-    },
-    200
+  @ApiBody({ type: LeaveWorkspaceBody })
+  @ApiSuccessResponse(LeaveWorkspaceResponseDto, 200)
+  @ApiErrorResponse(404, '해당 유저의 워크스페이스가 존재하지 않습니다.')
+  @ApiErrorResponse(
+    400,
+    '다른 멤버가 남아 있어 OWNER는 떠날 수 없습니다. 소유권을 이전 하거나, 삭제해주세요.'
   )
   async leaveWorkspace(@Request() req: any, @Body() body: LeaveWorkspaceBody) {
     const userId = req.user?.user_id;

--- a/src/workspace/workspace.controller.ts
+++ b/src/workspace/workspace.controller.ts
@@ -4,6 +4,7 @@ import {
   Delete,
   Get,
   Param,
+  Patch,
   Post,
   Query,
   Request,
@@ -27,6 +28,7 @@ import {
   LeaveWorkspaceBody,
   LeaveWorkspaceResponseDto
 } from './dto/leaveWorkspace.dto';
+import { RenameWorkspaceBody } from './dto/renameWorkspace.dto';
 
 @Controller('workspace')
 @UseGuards(JwtAuthGuard)
@@ -42,6 +44,31 @@ export class WorkspaceController {
   async workspaceList(@Request() req: any): Promise<UserWokrpaceInfoDto[]> {
     const userId = req.user?.user_id;
     return await this.workspaceService.userWorkspaceInfo(userId);
+  }
+
+  @Patch('/:workspaceId')
+  @ApiOperation({
+    summary: '워크스페이스 이름 변경',
+    description: 'OWNER 유저가 워크스페이스의 title을 변경합니다.'
+  })
+  @ApiBody({ type: RenameWorkspaceBody })
+  @ApiSuccessResponse(
+    {
+      type: 'string',
+      example: '이름 변경 성공'
+    },
+    200
+  )
+  @ApiErrorResponse(404, '해당 유저의 워크스페이스가 존재하지 않습니다.')
+  @ApiErrorResponse(403, 'OWNER만 워크스페이스 이름을 변경할 수 있습니다.')
+  async renameWorkspace(
+    @Request() req: any,
+    @Param('workspaceId') workspaceId: string,
+    @Body() body: RenameWorkspaceBody
+  ) {
+    const userId = req.user?.user_id;
+    await this.workspaceService.renameWorkspace(userId, workspaceId, body);
+    return '이름 변경 성공';
   }
 
   @Post('/')

--- a/src/workspace/workspace.module.ts
+++ b/src/workspace/workspace.module.ts
@@ -7,6 +7,7 @@ import { WorkspaceRepository } from './workspace.repository';
 @Module({
   imports: [NodeModule],
   controllers: [WorkspaceController],
-  providers: [WorkspaceService, WorkspaceRepository]
+  providers: [WorkspaceService, WorkspaceRepository],
+  exports: [WorkspaceService]
 })
 export class WorkspaceModule {}

--- a/src/workspace/workspace.repository.ts
+++ b/src/workspace/workspace.repository.ts
@@ -10,7 +10,8 @@ export class WorkspaceRepository {
   async selectUserWorkspace(userId: string) {
     return await this.prisma.client.users_workspaces.findMany({
       where: {
-        user_id: userId
+        user_id: userId,
+        deleted_at: null
       },
       include: {
         workspaces: {
@@ -49,7 +50,8 @@ export class WorkspaceRepository {
         user_id_workspace_id: {
           user_id: userId,
           workspace_id: workspaceId
-        }
+        },
+        deleted_at: null
       }
     });
   }
@@ -59,7 +61,8 @@ export class WorkspaceRepository {
         user_id_workspace_id: {
           user_id: userId,
           workspace_id: workspaceId
-        }
+        },
+        deleted_at: null
       },
       data: { deleted_at: new Date() }
     });

--- a/src/workspace/workspace.repository.ts
+++ b/src/workspace/workspace.repository.ts
@@ -43,10 +43,13 @@ export class WorkspaceRepository {
   }
 
   async checkWorkspace(userId: string, workspaceId: string) {
-    return await this.prisma.client.users_workspaces.findFirst({
+    if (!userId || !workspaceId) return null;
+    return await this.prisma.client.users_workspaces.findUnique({
       where: {
-        user_id: userId,
-        workspace_id: workspaceId
+        user_id_workspace_id: {
+          user_id: userId,
+          workspace_id: workspaceId
+        }
       }
     });
   }

--- a/src/workspace/workspace.repository.ts
+++ b/src/workspace/workspace.repository.ts
@@ -65,19 +65,23 @@ export class WorkspaceRepository {
     });
   }
 
-  async countActiveMembers(workspaceId: string): Promise<number> {
-    return await this.prisma.client.users_workspaces.count({
-      where: {
-        workspace_id: workspaceId,
-        deleted_at: null
-      }
-    });
-  }
-
   async softDeleteWorkspace(workspaceId: string) {
     return await this.prisma.client.workspaces.update({
       where: { workspace_id: workspaceId },
       data: { deleted_at: new Date() }
+    });
+  }
+
+  async softDeleteAllMembers(workspaceId: string) {
+    return await this.prisma.client.users_workspaces.updateMany({
+      where: { workspace_id: workspaceId, deleted_at: null },
+      data: { deleted_at: new Date() }
+    });
+  }
+
+  async countActiveUserWorkspaces(userId: string): Promise<number> {
+    return await this.prisma.client.users_workspaces.count({
+      where: { user_id: userId, deleted_at: null }
     });
   }
 }

--- a/src/workspace/workspace.repository.ts
+++ b/src/workspace/workspace.repository.ts
@@ -68,6 +68,13 @@ export class WorkspaceRepository {
     });
   }
 
+  async updateWorkspaceTitle(workspaceId: string, title: string) {
+    return await this.prisma.client.workspaces.update({
+      where: { workspace_id: workspaceId },
+      data: { title: title }
+    });
+  }
+
   async softDeleteWorkspace(workspaceId: string) {
     return await this.prisma.client.workspaces.update({
       where: { workspace_id: workspaceId },

--- a/src/workspace/workspace.service.ts
+++ b/src/workspace/workspace.service.ts
@@ -23,6 +23,7 @@ import {
 import { LeaveWorkspaceBody } from './dto/leaveWorkspace.dto';
 import { workspace_role_enum } from '../generated/prisma/client';
 import { PresenceMember } from '../ws/ws.event';
+import { RenameWorkspaceBody } from './dto/renameWorkspace.dto';
 
 const WORKSPACE_SYNC_TTL = 60 * 10;
 const WS_PRESENCE_TTL_SEC = 60 * 60 * 24;
@@ -203,6 +204,25 @@ export class WorkspaceService {
 
     await this.workspaceRepository.softDeleteAllMembers(workspaceId);
     await this.workspaceRepository.softDeleteWorkspace(workspaceId);
+  }
+
+  async renameWorkspace(
+    userId: string,
+    workspaceId: string,
+    body: RenameWorkspaceBody
+  ) {
+    const check = await this.checkExist(userId, workspaceId);
+    if (check.deleted_at)
+      throw new NotFoundException(
+        '해당 유저의 워크스페이스가 존재하지 않습니다.'
+      );
+    if (check.role !== 'OWNER')
+      throw new ForbiddenException(
+        'OWNER만 워크스페이스 이름을 변경할 수 있습니다.'
+      );
+
+    const { title } = body;
+    await this.workspaceRepository.updateWorkspaceTitle(workspaceId, title);
   }
 
   async upsertPresence(

--- a/src/workspace/workspace.service.ts
+++ b/src/workspace/workspace.service.ts
@@ -20,7 +20,7 @@ import {
   JoinWorkspaceBody as InviteWorkspaceBody,
   InviteWOrkspaceResponseDto
 } from './dto/joinWorkspace.dto';
-import { LeaveWorkspaceBody } from './dto/leaveWorkspace';
+import { LeaveWorkspaceBody } from './dto/leaveWorkspace.dto';
 import { workspace_role_enum } from '../generated/prisma/client';
 
 const WORKSPACE_SYNC_TTL = 60 * 10;

--- a/src/workspace/workspace.service.ts
+++ b/src/workspace/workspace.service.ts
@@ -22,8 +22,10 @@ import {
 } from './dto/joinWorkspace.dto';
 import { LeaveWorkspaceBody } from './dto/leaveWorkspace.dto';
 import { workspace_role_enum } from '../generated/prisma/client';
+import { PresenceMember } from '../ws/ws.event';
 
 const WORKSPACE_SYNC_TTL = 60 * 10;
+const WS_PRESENCE_TTL_SEC = 60 * 60 * 24;
 
 @Injectable()
 export class WorkspaceService {
@@ -180,5 +182,28 @@ export class WorkspaceService {
       workspaceId,
       stored.role
     );
+  }
+
+  async upsertPresence(
+    workspaceId: string,
+    member: PresenceMember
+  ): Promise<void> {
+    const key = REDIS_KEYS.WS_PRESENCE(workspaceId);
+    const client = this.redisService.getClient();
+    await client.hSet(key, member.userId, JSON.stringify(member));
+    await client.expire(key, WS_PRESENCE_TTL_SEC);
+  }
+
+  async removePresence(workspaceId: string, userId: string): Promise<void> {
+    await this.redisService
+      .getClient()
+      .hDel(REDIS_KEYS.WS_PRESENCE(workspaceId), userId);
+  }
+
+  async listPresence(workspaceId: string): Promise<PresenceMember[]> {
+    const raw = await this.redisService
+      .getClient()
+      .hGetAll(REDIS_KEYS.WS_PRESENCE(workspaceId));
+    return Object.values(raw).map((s) => JSON.parse(s) as PresenceMember);
   }
 }

--- a/src/workspace/workspace.service.ts
+++ b/src/workspace/workspace.service.ts
@@ -79,14 +79,9 @@ export class WorkspaceService {
     }
 
     if (membership.role === 'OWNER') {
-      const activeMembers =
-        await this.workspaceRepository.countActiveMembers(workspaceId);
-      if (activeMembers > 1) {
-        throw new BadRequestException(
-          '다른 멤버가 남아 있어 OWNER는 떠날 수 없습니다. 소유권을 이전 하거나, 삭제해주세요.'
-        );
-      }
-      await this.workspaceRepository.softDeleteWorkspace(workspaceId);
+      throw new BadRequestException(
+        'OWNER는 워크스페이스를 떠날 수 없습니다. 소유권을 이전하거나 워크스페이스를 삭제해주세요.'
+      );
     }
 
     await this.workspaceRepository.leaveWorkspace(userId, workspaceId);
@@ -123,8 +118,7 @@ export class WorkspaceService {
       throw new NotFoundException(
         '해당 유저의 워크스페이스가 존재하지 않습니다.'
       );
-    // if (check.role !== role)
-    //   throw new BadRequestException('워크스페이스 권한이 일치하지 않습니다.');
+    return check;
   }
 
   async inviteWorkspace(
@@ -136,6 +130,9 @@ export class WorkspaceService {
       userId,
       workspaceId
     );
+
+    const server_url = process.env.SERVER_URL;
+    const api_version = process.env.API_VERSION;
 
     if (!checkHasPerimission || checkHasPerimission.role === 'VIEWER')
       throw new ForbiddenException(
@@ -156,7 +153,7 @@ export class WorkspaceService {
     return {
       code: code,
       //TOOD: baseURL 형식으로 변경
-      url: `http://localhost:3000/workspace/join/${workspaceId}`
+      url: `${server_url}/${api_version}/workspace/join/${workspaceId}`
     };
   }
 
@@ -182,6 +179,30 @@ export class WorkspaceService {
       workspaceId,
       stored.role
     );
+  }
+
+  @Transactional()
+  async deleteWorkspace(workspaceId: string, userId: string) {
+    const check = await this.checkExist(userId, workspaceId);
+
+    if (check.deleted_at)
+      throw new NotFoundException(
+        '해당 유저의 워크스페이스가 존재하지 않습니다.'
+      );
+    if (check.role !== 'OWNER')
+      throw new ForbiddenException(
+        'OWNER가 아닌 유저는 워크스페이스를 삭제할 수 없습니다.'
+      );
+
+    const activeCount =
+      await this.workspaceRepository.countActiveUserWorkspaces(userId);
+    if (activeCount <= 1)
+      throw new BadRequestException(
+        '워크스페이스가 최소 한개는 남아있어야 합니다.'
+      );
+
+    await this.workspaceRepository.softDeleteAllMembers(workspaceId);
+    await this.workspaceRepository.softDeleteWorkspace(workspaceId);
   }
 
   async upsertPresence(

--- a/src/ws/ws.event.ts
+++ b/src/ws/ws.event.ts
@@ -73,6 +73,18 @@ export interface CursorLeaveEvent {
   userId: string;
 }
 
+export interface PresenceMember {
+  userId: string;
+  userName: string;
+  color: string;
+  profile: string | null;
+}
+
+export interface PresenceStateEvent {
+  workspaceId: string;
+  members: PresenceMember[];
+}
+
 // 이벤트 추가 시 여기에 union으로 추가
 
 export type WsEvent =

--- a/src/ws/ws.gateway.spec.ts
+++ b/src/ws/ws.gateway.spec.ts
@@ -4,6 +4,8 @@ import { JwtService } from '@nestjs/jwt';
 import { YjsDocManager } from '../yjs/yjs-doc-manager';
 import { YjsWsAwarenessService } from '../yjs/yjs-ws-awareness.service';
 import { WorkspaceRepository } from '../workspace/workspace.repository';
+import { WorkspaceService } from '../workspace/workspace.service';
+import { WsMetricsService } from '../common/metrics';
 import { Socket, Server } from 'socket.io';
 
 describe('WsGateway', () => {
@@ -17,8 +19,8 @@ describe('WsGateway', () => {
         {
           provide: JwtService,
           useValue: {
-            verify: jest.fn(),
-          },
+            verify: jest.fn()
+          }
         },
         {
           provide: YjsDocManager,
@@ -27,24 +29,39 @@ describe('WsGateway', () => {
             addClient: jest.fn(),
             removeClient: jest.fn(),
             scheduleSave: jest.fn(),
-            cleanupNode: jest.fn().mockResolvedValue(undefined),
-          },
+            cleanupNode: jest.fn().mockResolvedValue(undefined)
+          }
         },
         {
           provide: YjsWsAwarenessService,
           useValue: {
             getCachedAwareness: jest.fn().mockResolvedValue(null),
             cacheAwareness: jest.fn().mockResolvedValue(undefined),
-            deleteAwareness: jest.fn().mockResolvedValue(undefined),
-          },
+            deleteAwareness: jest.fn().mockResolvedValue(undefined)
+          }
         },
         {
           provide: WorkspaceRepository,
           useValue: {
-            checkWorkspace: jest.fn(),
-          },
+            checkWorkspace: jest.fn()
+          }
         },
-      ],
+        {
+          provide: WorkspaceService,
+          useValue: {
+            upsertPresence: jest.fn().mockResolvedValue(undefined),
+            removePresence: jest.fn().mockResolvedValue(undefined),
+            listPresence: jest.fn().mockResolvedValue([])
+          }
+        },
+        {
+          provide: WsMetricsService,
+          useValue: {
+            increment: jest.fn(),
+            decrement: jest.fn()
+          }
+        }
+      ]
     }).compile();
 
     gateway = module.get<WsGateway>(WsGateway);
@@ -53,7 +70,7 @@ describe('WsGateway', () => {
     // Inject a mock Server
     gateway.server = {
       to: jest.fn().mockReturnThis(),
-      emit: jest.fn(),
+      emit: jest.fn()
     } as unknown as Server;
   });
 
@@ -66,7 +83,7 @@ describe('WsGateway', () => {
       const client = {
         handshake: { auth: {}, query: {} },
         disconnect: jest.fn(),
-        data: {},
+        data: {}
       } as unknown as Socket;
 
       await gateway.handleConnection(client);
@@ -80,7 +97,7 @@ describe('WsGateway', () => {
       const client = {
         handshake: { auth: { token: 'valid-token' }, query: {} },
         disconnect: jest.fn(),
-        data: {},
+        data: {}
       } as unknown as Socket;
 
       await gateway.handleConnection(client);
@@ -97,7 +114,7 @@ describe('WsGateway', () => {
       const client = {
         handshake: { auth: { token: 'bad-token' }, query: {} },
         disconnect: jest.fn(),
-        data: {},
+        data: {}
       } as unknown as Socket;
 
       await gateway.handleConnection(client);
@@ -111,7 +128,7 @@ describe('WsGateway', () => {
       const client = {
         handshake: { auth: {}, query: { token: 'query-token' } },
         disconnect: jest.fn(),
-        data: {},
+        data: {}
       } as unknown as Socket;
 
       await gateway.handleConnection(client);
@@ -125,12 +142,70 @@ describe('WsGateway', () => {
       const client = {
         join: jest.fn(),
         emit: jest.fn(),
-        data: {},
+        data: { userId: 'user-1' }
       } as unknown as Socket;
 
-      await gateway.handleJoin({ workspaceId: 'ws-abc' }, client);
+      await gateway.handleJoin(
+        {
+          workspaceId: 'ws-abc',
+          userName: 'Alice',
+          color: '#f00',
+          profile: null
+        },
+        client
+      );
       expect(client.join).toHaveBeenCalledWith('ws-abc');
       expect(client.join).toHaveBeenCalledWith('yjs:ws:ws-abc');
+    });
+
+    it('should upsert presence and broadcast presence_state', async () => {
+      const workspaceService = (gateway as unknown as { workspaceService: any })
+        .workspaceService;
+      workspaceService.listPresence.mockResolvedValueOnce([
+        {
+          userId: 'user-1',
+          userName: 'Alice',
+          color: '#f00',
+          profile: null
+        }
+      ]);
+
+      const client = {
+        join: jest.fn(),
+        emit: jest.fn(),
+        data: { userId: 'user-1' }
+      } as unknown as Socket;
+
+      await gateway.handleJoin(
+        {
+          workspaceId: 'ws-abc',
+          userName: 'Alice',
+          color: '#f00',
+          profile: null
+        },
+        client
+      );
+
+      expect(workspaceService.upsertPresence).toHaveBeenCalledWith('ws-abc', {
+        userId: 'user-1',
+        userName: 'Alice',
+        color: '#f00',
+        profile: null
+      });
+      expect(gateway.server.to).toHaveBeenCalledWith('ws-abc');
+      expect(
+        (gateway.server.to('ws-abc') as unknown as { emit: jest.Mock }).emit
+      ).toHaveBeenCalledWith('presence_state', {
+        workspaceId: 'ws-abc',
+        members: [
+          {
+            userId: 'user-1',
+            userName: 'Alice',
+            color: '#f00',
+            profile: null
+          }
+        ]
+      });
     });
   });
 
@@ -138,14 +213,14 @@ describe('WsGateway', () => {
     it('should broadcast node_position_live to the workspace room excluding sender', () => {
       const mockEmit = jest.fn();
       const client = {
-        to: jest.fn().mockReturnValue({ emit: mockEmit }),
+        to: jest.fn().mockReturnValue({ emit: mockEmit })
       } as unknown as Socket;
 
       const payload = {
         workspaceId: 'ws-abc',
         nodeId: 'node-1',
         x: 150,
-        y: 300,
+        y: 300
       };
 
       gateway.handleLivePosition(payload, client);
@@ -157,14 +232,14 @@ describe('WsGateway', () => {
     it('should forward the exact payload without modification', () => {
       const mockEmit = jest.fn();
       const client = {
-        to: jest.fn().mockReturnValue({ emit: mockEmit }),
+        to: jest.fn().mockReturnValue({ emit: mockEmit })
       } as unknown as Socket;
 
       const payload = {
         workspaceId: 'ws-xyz',
         nodeId: 'node-99',
         x: -42.5,
-        y: 1000.123,
+        y: 1000.123
       };
 
       gateway.handleLivePosition(payload, client);
@@ -189,14 +264,14 @@ describe('WsGateway', () => {
           nodeType: 'PROJECT',
           position: { x: 0, y: 0 },
           data: {},
-          createdAt: '2026-01-01',
-        },
+          createdAt: '2026-01-01'
+        }
       };
 
       gateway.broadcast(event);
       expect(gateway.server.to).toHaveBeenCalledWith('ws-abc');
       expect(
-        (gateway.server.to('ws-abc') as unknown as { emit: jest.Mock }).emit,
+        (gateway.server.to('ws-abc') as unknown as { emit: jest.Mock }).emit
       ).toHaveBeenCalledWith('workspace_event', event);
     });
   });

--- a/src/ws/ws.gateway.ts
+++ b/src/ws/ws.gateway.ts
@@ -11,14 +11,15 @@ import {
 import { Server, Namespace, Socket } from 'socket.io';
 import { instrument } from '@socket.io/admin-ui';
 import { JwtService } from '@nestjs/jwt';
-import { Logger } from '@nestjs/common';
+import { forwardRef, Inject, Logger } from '@nestjs/common';
 import * as syncProtocol from 'y-protocols/sync';
 import * as encoding from 'lib0/encoding';
 import * as decoding from 'lib0/decoding';
-import { WsEvent } from './ws.event';
+import { PresenceStateEvent, WsEvent } from './ws.event';
 import { YjsDocManager } from '../yjs/yjs-doc-manager';
 import { YjsWsAwarenessService } from '../yjs/yjs-ws-awareness.service';
 import { WorkspaceRepository } from '../workspace/workspace.repository';
+import { WorkspaceService } from '../workspace/workspace.service';
 import { WsMetricsService } from '../common/metrics';
 import {
   YJS_EVENT,
@@ -47,6 +48,8 @@ export class WsGateway
     private readonly yjsDocManager: YjsDocManager,
     private readonly yjsWsAwareness: YjsWsAwarenessService,
     private readonly workspaceRepository: WorkspaceRepository,
+    @Inject(forwardRef(() => WorkspaceService))
+    private readonly workspaceService: WorkspaceService,
     private readonly wsMetrics: WsMetricsService
   ) {}
 
@@ -76,20 +79,24 @@ export class WsGateway
       const payload = this.jwtService.verify(token);
       client.data.userId = payload.user_id;
       this.wsMetrics.increment();
-    } catch {
+    } catch (err) {
       client.disconnect();
     }
   }
 
-  handleDisconnect(client: Socket) {
+  async handleDisconnect(client: Socket) {
     if (client.data?.userId) {
       this.wsMetrics.decrement();
     }
     const workspaceId = client.data?.workspaceId;
+    const userId = client.data?.userId;
     if (workspaceId) {
-      client.to(workspaceId).emit('cursor_leave', {
-        userId: client.data.userId
-      });
+      client.to(workspaceId).emit('cursor_leave', { userId });
+
+      if (userId) {
+        await this.workspaceService.removePresence(workspaceId, userId);
+        await this.broadcastPresence(workspaceId);
+      }
     }
 
     // Yjs cleanup: 모든 참여 중인 doc에서 제거
@@ -102,15 +109,41 @@ export class WsGateway
     }
   }
 
+  private async broadcastPresence(workspaceId: string): Promise<void> {
+    const members = await this.workspaceService.listPresence(workspaceId);
+    const event: PresenceStateEvent = { workspaceId, members };
+    this.server.to(workspaceId).emit('presence_state', event);
+  }
+
   // ── 기존 이벤트 (변경 없음) ───────────────────────────────────
 
   @SubscribeMessage('join_workspace')
   async handleJoin(
-    @MessageBody() payload: { workspaceId: string },
+    @MessageBody()
+    payload: {
+      workspaceId: string;
+      userName: string;
+      color: string;
+      profile?: string | null;
+    },
     @ConnectedSocket() client: Socket
   ) {
     this.logger.debug('조인완료');
-    const { workspaceId } = payload;
+    const { workspaceId, userName, color, profile = null } = payload;
+    const userId = client.data.userId;
+
+    if (!userId) {
+      return { ok: false, error: '로그인이 필요합니다.' };
+    }
+
+    const membership = await this.workspaceRepository.checkWorkspace(
+      userId,
+      workspaceId
+    );
+
+    if (!membership) {
+      return { ok: false, error: '워크스페이스 멤버가 아닙니다' };
+    }
 
     client.join(workspaceId);
     client.data.workspaceId = workspaceId;
@@ -126,6 +159,16 @@ export class WsGateway
         data: Array.from(new Uint8Array(cached))
       });
     }
+
+    await this.workspaceService.upsertPresence(workspaceId, {
+      userId,
+      userName,
+      color,
+      profile
+    });
+    await this.broadcastPresence(workspaceId);
+
+    return { ok: true };
   }
 
   @SubscribeMessage('node_position_live')

--- a/src/ws/ws.module.ts
+++ b/src/ws/ws.module.ts
@@ -1,12 +1,18 @@
-import { Module } from '@nestjs/common';
+import { forwardRef, Module } from '@nestjs/common';
 import { WsGateway } from './ws.gateway';
 import { AuthModule } from '../auth/auth.module';
 import { YjsModule } from '../yjs/yjs.module';
+import { WorkspaceModule } from '../workspace/workspace.module';
 import { WorkspaceRepository } from '../workspace/workspace.repository';
 import { MetricsModule } from '../common/metrics';
 
 @Module({
-  imports: [AuthModule, YjsModule, MetricsModule],
+  imports: [
+    AuthModule,
+    YjsModule,
+    MetricsModule,
+    forwardRef(() => WorkspaceModule)
+  ],
   providers: [WsGateway, WorkspaceRepository],
   exports: [WsGateway]
 })


### PR DESCRIPTION
## 변경 요약

워크스페이스 단위로 현재 접속 중인 멤버 목록을 실시간으로 동기화하는 `presence_state` WebSocket 이벤트와 Redis 기반 presence 저장소를 추가했다.

## 추가/수정된 파일


  
| 분류 | 이벤트 | 비고 |
|---|---|---|
| 신규 (server → client) | `presence_state` | 워크스페이스 접속자 목록 broadcast |
| 변경 (client → server) | `join_workspace` | payload에 `userName`/`color`/`profile` 추가, ack `{ ok, error? }` 형태로 표준화 |
| 변경 (server → client) | `cursor_leave` | payload 정리: `{ userId }`만 전달 — 동작은 동일 |
| 신규 `@SubscribeMessage` | 없음 | 클라이언트가 새로 emit해야 할 이벤트는 없음 |
  


| 파일                                                  | 변경 내용                                                                                                                                            |
| ----------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------- |
| `src/ws/ws.event.ts`                                  | `PresenceMember`, `PresenceStateEvent` 인터페이스 추가                                                                                           |
| `src/ws/ws.gateway.ts`                                | `join_workspace` payload 확장(`userName`/`color`/`profile`), 멤버십 검증 추가, `broadcastPresence` 추가, `handleDisconnect`에서 presence 제거·재방송 |
| `src/ws/ws.module.ts`                                 | `WorkspaceService` 주입을 위한 의존성 wiring                                                                                                         |
| `src/workspace/workspace.service.ts`                  | `upsertPresence` / `removePresence` / `listPresence` 메서드 추가                                                                                     |
| `src/workspace/workspace.repository.ts`               | presence 관련 호출 정리                                                                                                                              |
| `src/workspace/workspace.module.ts`                   | `WorkspaceService` export로 `WsGateway`에서 사용 가능하도록 변경                                                                                     |
| `src/redis/redis.keys.ts`                             | `WS_PRESENCE(workspaceId)` 키 추가                                                                                                                   |
| `src/node/node.module.ts`, `src/node/node.service.ts` | 의존성 그래프 정리에 따른 부수 변경                                                                                                                  |
| `src/ws/ws.gateway.spec.ts`                           | presence 이벤트·멤버십 검증 케이스 추가                                                                                                              |
| `package.json`, `pnpm-lock.yaml`                      | 의존성 업데이트                                                                                                                                      |

## PR 설명

### 배경

기존 워크스페이스 WS 흐름에는 "지금 누가 들어와 있는지"를 클라이언트가 알 방법이 없었다. 커서 이벤트(`cursor_move`)는 마우스 움직임에 의존해서, 가만히 있는 사용자는 보이지 않았고 페이지 진입 직후의 late-joiner도 다른 멤버의 존재를 알 수 없었다. 멤버 리스트 갱신을 위해 별도 REST 폴링을 두는 것도 비효율적이라, WS 레벨에서 권위 있는 단일 presence 채널을 두기로 했다.

또한 기존 `handleJoin`은 `join_workspace`를 호출하기만 하면 JWT 인증된 누구든 임의의 `workspaceId` 룸에 들어갈 수 있는 구조였다. presence를 도입하는 김에 DB로 멤버십을 검증하도록 함께 강화했다.

### 변경 내용

**1) Redis presence 저장소 (`WorkspaceService`)**

- 키: `ws:presence:{workspaceId}` — Hash (field: `userId`, value: JSON-stringified `PresenceMember`)
- TTL: 24시간 (장기 미접속 워크스페이스 키를 자동 회수)
- `upsertPresence` / `removePresence` / `listPresence` 3개 API 제공

**2) WS 이벤트 추가 (`ws.event.ts`)**

```ts
interface PresenceMember {
  userId: string;
  userName: string;
  color: string;
  profile: string | null;
}
interface PresenceStateEvent {
  workspaceId: string;
  members: PresenceMember[];
}
```

서버 → 클라이언트 이벤트명: `presence_state`. 전체 현재 목록을 매번 보내는 **state-replace** 방식 (단순성·재연결 회복력 우선).

**3) `join_workspace` 동작 변경 (`ws.gateway.ts`)**

- payload에 `userName`, `color`, `profile?` 추가
- 멤버십 검증 후 `client.join(workspaceId)`
- presence Redis upsert → 같은 룸에 `presence_state` broadcast
- ack 응답을 `{ ok: true }` / `{ ok: false, error }` 형태로 표준화

**4) `handleDisconnect`**

- 기존 `cursor_leave` 방송 유지
- presence Redis에서 해당 `userId` 제거 → `presence_state` 재방송
- Yjs cleanup 로직은 그대로 유지

**5) DI 변경**

- `WsGateway`에 `WorkspaceService` 주입 — 순환 의존을 피하기 위해 `forwardRef` 사용
- `WorkspaceModule`에서 `WorkspaceService` export

### 테스트

- **단위 테스트 (`src/ws/ws.gateway.spec.ts`):**
  - 멤버 → `join_workspace` ack `{ ok: true }`, presence upsert + broadcast 호출 검증
  - 비멤버 → ack `{ ok: false, error }`, room join / presence upsert 미호출 검증
  - disconnect 시 presence 제거 + 재방송 검증
- **로컬 시나리오:**
  - 클라 A·B가 같은 워크스페이스 접속 → 양쪽 모두에서 `presence_state.members.length === 2`
  - A 새로고침/탭 종료 → B의 `presence_state.members.length === 1`로 갱신
  - 비멤버 토큰으로 `join_workspace` 시도 → `{ ok: false }`, 룸 이벤트 미수신
- `pnpm run lint`, `pnpm run build`, `pnpm run test -- --testPathPattern=ws` 통과

### 주의사항 / 후속 작업

- **클라이언트 변경 필요:** `join_workspace` payload에 `userName`/`color`/`profile`을 반드시 포함해야 함. 기존 호출은 빈 사용자 정보로 broadcast되므로 프런트 동시 배포 필요.
- **`presence_state`는 state-replace 방식**이라 페이로드 크기가 멤버 수에 비례한다. 수십~수백 명 규모까지는 충분하지만, 더 큰 워크스페이스가 생기면 delta(`join`/`leave`) 방식 도입 검토.
- **`checkWorkspace`의 `deleted_at` 미필터링 이슈**는 별도 작업으로 분리. 현재는 soft-delete된 멤버도 presence에 잡힐 수 있음.
- **Heartbeat 미구현:** WS가 비정상 종료된 후에도 24시간 TTL까지 presence가 남는다. 추후 클라이언트 heartbeat + TTL 단축 또는 socket-level keepalive로 보완 가능.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * 워크스페이스 단위 실시간 사용자 프레즌스(접속 상태) 관리 및 브로드캐스트 추가
  * 요청별 컨텍스트 추적(요청 ID) 및 일관된 요청/응답 로깅 포맷 도입
  * 워크스페이스 삭제·이름 변경 API 및 관련 DTO 추가

* **버그 수정**
  * 워크스페이스 탈퇴/권한 처리 로직 정비 및 에러 응답 명세 개선

* **Chores**
  * 실시간 통신 라이브러리 지원 추가 (클라이언트 관련)

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Won-Life/Aideep_backend/pull/28?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->