### PR TITLE
Feat : 노드 검색 API 추가 (FTS + trigram)

### DIFF
--- a/src/node/dto/nodeSearch.dto.ts
+++ b/src/node/dto/nodeSearch.dto.ts
@@ -1,0 +1,57 @@
+import { ApiProperty } from '@nestjs/swagger';
+
+export class NodeSearchResultDto {
+  @ApiProperty({ description: '노드 ID', format: 'uuid' })
+  nodeId!: string;
+
+  @ApiProperty({ description: '워크스페이스 ID', format: 'uuid' })
+  workspaceId!: string;
+
+  @ApiProperty({ description: '노드 제목', nullable: true })
+  title!: string | null;
+
+  @ApiProperty({ description: '노드 타입' })
+  nodeType!: string;
+
+  @ApiProperty({ description: '노드 깊이', nullable: true })
+  depth!: number | null;
+
+  @ApiProperty({ description: 'X 좌표', nullable: true })
+  positionX!: number | null;
+
+  @ApiProperty({ description: 'Y 좌표', nullable: true })
+  positionY!: number | null;
+
+  @ApiProperty({ description: '버전' })
+  version!: number;
+
+  @ApiProperty({ description: '생성 시각', format: 'date-time' })
+  createdAt!: Date;
+
+  @ApiProperty({ description: '수정 시각', format: 'date-time' })
+  updatedAt!: Date;
+
+  @ApiProperty({
+    description: '검색 점수 (0~1, 높을수록 query 와 유사). FTS 비활성 시 1.',
+    example: 0.42
+  })
+  score!: number;
+
+  @ApiProperty({
+    description: '매칭 부위 snippet (최대 120자). FTS 비활성 시 빈 문자열.',
+    example: '...키워드 주변 텍스트...'
+  })
+  snippet!: string;
+}
+
+export class NodeSearchResponseDto {
+  @ApiProperty({ type: [NodeSearchResultDto] })
+  items!: NodeSearchResultDto[];
+
+  @ApiProperty({
+    description: '다음 페이지 cursor. null 이면 더 이상 결과 없음.',
+    nullable: true,
+    example: '0.123|550e8400-e29b-41d4-a716-446655440000'
+  })
+  nextCursor!: string | null;
+}

--- a/src/node/node.controller.ts
+++ b/src/node/node.controller.ts
@@ -9,13 +9,15 @@ import {
   Request,
   Inject,
   LoggerService,
-  Delete
+  Delete,
+  Query
 } from '@nestjs/common';
 import { NodeService } from './node.service';
 import {
   ApiBearerAuth,
   ApiOperation,
   ApiParam,
+  ApiQuery,
   ApiTags
 } from '@nestjs/swagger';
 import { JwtAuthGuard } from 'src/auth/guards/jwt.guard';
@@ -28,6 +30,7 @@ import { Node } from './node.model';
 import { WINSTON_MODULE_NEST_PROVIDER } from 'nest-winston';
 import { ApiSuccessResponse } from 'src/common/response/api-success-response.decorator';
 import { NodeDetailDto } from './dto/nodeDetail.dto';
+import { NodeSearchResponseDto } from './dto/nodeSearch.dto';
 
 @ApiTags('Node')
 @Controller('workspace/:workspaceId/node')
@@ -77,6 +80,45 @@ export class NodeController {
     console.log(node);
     const nodeId = await this.nodeService.createMarkdownNode(node);
     return { nodeId };
+  }
+
+  @Get('search')
+  @ApiOperation({
+    summary: '노드 검색',
+    description:
+      '워크스페이스 내 노드를 title + content(JSON 전체 평탄화) 기준으로 substring + trigram similarity 검색합니다. FEATURE_FTS=true 시 GIN 인덱스 기반 가속 + ranking + snippet + cursor 페이지네이션.'
+  })
+  @ApiQuery({
+    name: 'q',
+    description: '검색어 (1~200자)',
+    required: true,
+    type: String
+  })
+  @ApiQuery({
+    name: 'limit',
+    description: '결과 수 (기본 50, 최대 100)',
+    required: false,
+    type: Number
+  })
+  @ApiQuery({
+    name: 'cursor',
+    description: '다음 페이지 cursor (이전 응답의 nextCursor)',
+    required: false,
+    type: String
+  })
+  @ApiSuccessResponse(NodeSearchResponseDto, 200, '노드 검색 성공')
+  async searchNodes(
+    @Param('workspaceId') workspaceId: string,
+    @Query('q') query: string,
+    @Request() req: any,
+    @Query('limit') limit?: string,
+    @Query('cursor') cursor?: string
+  ): Promise<NodeSearchResponseDto> {
+    const userId = req.user?.user_id;
+    return await this.nodeService.searchNodes(workspaceId, query, userId, {
+      limit: limit !== undefined ? Number(limit) : undefined,
+      cursor
+    });
   }
 
   @Get(':nodeId')

--- a/src/node/node.repository.ts
+++ b/src/node/node.repository.ts
@@ -4,6 +4,21 @@ import { PrismaService } from 'src/prisma/prisma.service';
 import { Node } from './node.model';
 import { tree } from 'lib0';
 
+export type FtsRow = {
+  nodeId: string;
+  workspaceId: string;
+  title: string | null;
+  nodeType: string;
+  depth: number | null;
+  positionX: number | null;
+  positionY: number | null;
+  version: number;
+  createdAt: Date;
+  updatedAt: Date;
+  score: number;
+  snippet: string;
+};
+
 export type RawNodeItem = Prisma.nodesGetPayload<{
   select: {
     node_id: true;
@@ -213,6 +228,116 @@ export class NodeRepository {
         version: { increment: 1 }
       }
     });
+  }
+
+  async searchByQuery(
+    workspaceId: string,
+    query: string
+  ): Promise<RawNodeItem[]> {
+    return await this.prisma.client.nodes.findMany({
+      select: {
+        node_id: true,
+        title: true,
+        node_type: true,
+        content: true,
+        version: true,
+        created_at: true,
+        updated_at: true,
+        deleted_at: true,
+        position_x: true,
+        position_y: true,
+        workspace_id: true,
+        depth: true
+      },
+      where: {
+        workspace_id: workspaceId,
+        deleted_at: null,
+        OR: [
+          { title: { contains: query } },
+          {
+            content: {
+              string_contains: query
+            }
+          }
+        ]
+      }
+    });
+  }
+
+  async searchByFts(
+    workspaceId: string,
+    query: string,
+    limit: number,
+    cursor: { score: number; nodeId: string } | null
+  ): Promise<FtsRow[]> {
+    const fetchSize = limit + 1;
+    const rows = cursor
+      ? await this.prisma.client.$queryRaw<FtsRow[]>`
+          SELECT
+            node_id      AS "nodeId",
+            workspace_id AS "workspaceId",
+            title,
+            node_type    AS "nodeType",
+            depth,
+            position_x   AS "positionX",
+            position_y   AS "positionY",
+            version,
+            created_at   AS "createdAt",
+            updated_at   AS "updatedAt",
+            similarity(search_text, ${query})::float AS score,
+            CASE
+              WHEN position(lower(${query}) in lower(search_text)) > 0
+                THEN substring(
+                  search_text
+                  FROM greatest(1, position(lower(${query}) in lower(search_text)) - 40)
+                  FOR 120
+                )
+              ELSE left(coalesce(search_text, ''), 120)
+            END AS snippet
+          FROM nodes
+          WHERE workspace_id = ${workspaceId}::uuid
+            AND deleted_at IS NULL
+            AND search_text % ${query}
+            AND (
+              similarity(search_text, ${query}) < ${cursor.score}
+              OR (
+                similarity(search_text, ${query}) = ${cursor.score}
+                AND node_id > ${cursor.nodeId}::uuid
+              )
+            )
+          ORDER BY score DESC, "nodeId" ASC
+          LIMIT ${fetchSize}
+        `
+      : await this.prisma.client.$queryRaw<FtsRow[]>`
+          SELECT
+            node_id      AS "nodeId",
+            workspace_id AS "workspaceId",
+            title,
+            node_type    AS "nodeType",
+            depth,
+            position_x   AS "positionX",
+            position_y   AS "positionY",
+            version,
+            created_at   AS "createdAt",
+            updated_at   AS "updatedAt",
+            similarity(search_text, ${query})::float AS score,
+            CASE
+              WHEN position(lower(${query}) in lower(search_text)) > 0
+                THEN substring(
+                  search_text
+                  FROM greatest(1, position(lower(${query}) in lower(search_text)) - 40)
+                  FOR 120
+                )
+              ELSE left(coalesce(search_text, ''), 120)
+            END AS snippet
+          FROM nodes
+          WHERE workspace_id = ${workspaceId}::uuid
+            AND deleted_at IS NULL
+            AND search_text % ${query}
+          ORDER BY score DESC, "nodeId" ASC
+          LIMIT ${fetchSize}
+        `;
+    return rows;
   }
 
   async deleteNode(nodeId: string) {

--- a/src/node/node.service.ts
+++ b/src/node/node.service.ts
@@ -1,11 +1,16 @@
 import {
+  BadRequestException,
   forwardRef,
   Inject,
   Injectable,
   NotFoundException,
   UnauthorizedException
 } from '@nestjs/common';
-import { NodeRepository } from './node.repository';
+import { NodeRepository, FtsRow } from './node.repository';
+import {
+  NodeSearchResponseDto,
+  NodeSearchResultDto
+} from './dto/nodeSearch.dto';
 import { WorkspaceRepository } from 'src/workspace/workspace.repository';
 import { EdgeRepository } from 'src/edge/edge.repository';
 import { Node } from './node.model';
@@ -285,6 +290,107 @@ export class NodeService {
         }
       }
     }
+  }
+
+  private async checkExist(userId: string, workspaceId: string) {
+    const check = await this.workspaceRepository.checkWorkspace(
+      userId,
+      workspaceId
+    );
+    if (check === null)
+      throw new NotFoundException(
+        '해당 유저의 워크스페이스가 존재하지 않습니다.'
+      );
+    return check;
+  }
+
+  async searchByExactMatch(workspaceId: string, query: string, userId: string) {
+    await this.checkExist(userId, workspaceId);
+
+    return await this.nodeRespository.searchByQuery(workspaceId, query);
+  }
+
+  async searchNodes(
+    workspaceId: string,
+    rawQuery: string,
+    userId: string,
+    options: { limit?: number; cursor?: string } = {}
+  ): Promise<NodeSearchResponseDto> {
+    await this.checkExist(userId, workspaceId);
+
+    const query = (rawQuery ?? '').trim();
+    if (query.length < 1) {
+      throw new BadRequestException('검색어는 1자 이상이어야 합니다.');
+    }
+    if (query.length > 200) {
+      throw new BadRequestException('검색어는 200자 이하여야 합니다.');
+    }
+
+    const limit = Math.min(Math.max(options.limit ?? 50, 1), 100);
+
+    if (process.env.FEATURE_FTS !== 'true') {
+      const rows = await this.nodeRespository.searchByQuery(workspaceId, query);
+      const items = rows.slice(0, limit).map<NodeSearchResultDto>((r) => ({
+        nodeId: r.node_id,
+        workspaceId: r.workspace_id,
+        title: r.title,
+        nodeType: r.node_type as string,
+        depth: r.depth,
+        positionX: r.position_x,
+        positionY: r.position_y,
+        version: r.version,
+        createdAt: r.created_at,
+        updatedAt: r.updated_at,
+        score: 1,
+        snippet: ''
+      }));
+      return { items, nextCursor: null };
+    }
+
+    const cursor = this.parseCursor(options.cursor);
+    const rows = await this.nodeRespository.searchByFts(
+      workspaceId,
+      query,
+      limit,
+      cursor
+    );
+
+    const hasMore = rows.length > limit;
+    const page = hasMore ? rows.slice(0, limit) : rows;
+    const last = page[page.length - 1];
+    const nextCursor = hasMore && last ? `${last.score}|${last.nodeId}` : null;
+
+    return {
+      items: page.map<NodeSearchResultDto>((r) => this.toDto(r)),
+      nextCursor
+    };
+  }
+
+  private toDto(r: FtsRow): NodeSearchResultDto {
+    return {
+      nodeId: r.nodeId,
+      workspaceId: r.workspaceId,
+      title: r.title,
+      nodeType: r.nodeType,
+      depth: r.depth,
+      positionX: r.positionX,
+      positionY: r.positionY,
+      version: r.version,
+      createdAt: r.createdAt,
+      updatedAt: r.updatedAt,
+      score: r.score,
+      snippet: r.snippet ?? ''
+    };
+  }
+
+  private parseCursor(raw?: string): { score: number; nodeId: string } | null {
+    if (!raw) return null;
+    const [scoreStr, nodeId] = raw.split('|');
+    const score = Number(scoreStr);
+    if (!nodeId || Number.isNaN(score)) {
+      throw new BadRequestException('잘못된 cursor 형식입니다.');
+    }
+    return { score, nodeId };
   }
 
   async propagateDepth(


### PR DESCRIPTION
## Summary
- 워크스페이스 내 노드 검색 API `GET /workspace/:workspaceId/node/search` 추가 (title + content 평탄화)
- `FEATURE_FTS=true` 시 PostgreSQL `pg_trgm` GIN 인덱스 기반 trigram similarity + score + snippet + cursor 페이지네이션 활성화 (flag off 시 기존 `contains` fallback)
- 응답 DTO `NodeSearchResponseDto { items, nextCursor }` 신설, Swagger 응답 계약 정정

## 변경 내용
- `node.controller.ts` — `GET /search` 엔드포인트, `q`/`limit`/`cursor` 쿼리, Swagger 데코레이터
- `node.service.ts` — `searchNodes()` (1~200자 검증, FEATURE_FTS 분기, cursor 파싱), `searchByExactMatch()` 유지 (점진 제거 예정)
- `node.repository.ts` — `searchByQuery()` (fallback) + `searchByFts()` (`$queryRaw` similarity + cursor + 120자 snippet)
- `dto/nodeSearch.dto.ts` — `NodeSearchResultDto`, `NodeSearchResponseDto` 신규

## 운영 적용 안내
- 마이그레이션 `20260522000000_add_search_fts` (search_text generated column + GIN partial index) 별도 적용 필요 — `ADD COLUMN ... GENERATED STORED`는 테이블 rewrite 발생, 점검창 권장
- `.env`에 `FEATURE_FTS=true` 추가 시점부터 trigram 경로 활성화. flag off 기본값으로 안전 배포 가능

## Test plan
- [x] `pnpm build` 통과
- [ ] e2e: title/content/한국어/권한/빈 쿼리/cursor 시나리오
- [ ] 부하: 10k seed → p95 < 200ms

## 후속 작업
- `searchByExactMatch` 호출처 정리 후 제거
- false positive (JSON key match) 발생 시 content 필드 추출 전환 (Phase 2)
- 한국어 정확도 이슈 발생 시 `pg_bigm` 마이그레이션 (Phase 2 트리거)
- Rate limit (Throttler) 별도 PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 워크스페이스 내에서 노드를 검색할 수 있는 기능이 추가되었습니다.
  * 검색은 제목과 콘텐츠를 대상으로 하며, 관련성 점수에 따라 정렬된 결과를 제공합니다.
  * 커서 기반 페이지네이션을 지원하여 대량의 검색 결과를 효율적으로 탐색할 수 있습니다.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Won-Life/Aideep_backend/pull/32?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->